### PR TITLE
Test embedding with gat

### DIFF
--- a/machine_learning/.gitignore
+++ b/machine_learning/.gitignore
@@ -1,2 +1,3 @@
 glove/*
 .data/*
+sample_data.pkl

--- a/machine_learning/glove_embedding.py
+++ b/machine_learning/glove_embedding.py
@@ -1,0 +1,15 @@
+import os
+import bcolz
+import pickle
+
+UNKNOWN_WORD = "[unk]"
+
+# Setup glove embedding
+script_dir = os.path.dirname(__file__)
+glove_path = os.path.join(script_dir, "glove")
+
+word_vectors = bcolz.open(f'{glove_path}/6B.50.dat')[:]
+words = pickle.load(open(f'{glove_path}/6B.50_words.pkl', 'rb'))
+word2idx = pickle.load(open(f'{glove_path}/6B.50_idx.pkl', 'rb'))
+
+glove = {w: word_vectors[word2idx[w]] for w in words}

--- a/machine_learning/glove_embedding.py
+++ b/machine_learning/glove_embedding.py
@@ -3,6 +3,7 @@ import bcolz
 import pickle
 
 UNKNOWN_WORD = "[unk]"
+EMBED_DIM = 50
 
 # Setup glove embedding
 script_dir = os.path.dirname(__file__)

--- a/machine_learning/glove_gat.py
+++ b/machine_learning/glove_gat.py
@@ -1,0 +1,15 @@
+import torch
+import torch.nn as nn
+#
+from gat import GATFinal
+from glove_embedding import word_vectors
+
+class GloveGAT(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embedding = nn.EmbeddingBag.from_pretrained(word_vectors)
+        self.gat = GATFinal(embed_dim, output_size=2, K=1)
+
+    def forward(self, inputs, offsets, adj_matrix):
+        embedded = self.embedding(text, offsets)
+        return self.gat(embedded, adj_matrix)

--- a/machine_learning/glove_gat.py
+++ b/machine_learning/glove_gat.py
@@ -1,15 +1,51 @@
+import math
+import pickle
+#
 import torch
 import torch.nn as nn
+import torch.optim as optim
 #
 from gat import GATFinal
-from glove_embedding import word_vectors
+from glove_embedding import EMBED_DIM, word_vectors
 
 class GloveGAT(nn.Module):
     def __init__(self):
         super().__init__()
-        self.embedding = nn.EmbeddingBag.from_pretrained(word_vectors)
-        self.gat = GATFinal(embed_dim, output_size=2, K=1)
+        self.embedding = nn.EmbeddingBag.from_pretrained(torch.tensor(word_vectors))
+        self.gat = GATFinal(EMBED_DIM, output_size=1, K=1)
 
     def forward(self, inputs, offsets, adj_matrix):
-        embedded = self.embedding(text, offsets)
+        embedded = self.embedding(inputs, offsets).float()
         return self.gat(embedded, adj_matrix)
+
+def create_train_and_test(data):
+    pass
+
+def predict(model, data):
+    pass
+
+def train(model, inputs, offsets, adj_matrix, cls, lr=0.0001, iters=100):
+    optimizer = optim.SGD(model.parameters(), lr=lr)
+    criterion = nn.MSELoss()
+
+    tenth_iter = math.floor(iters / 10)
+    for i in range(iters):
+        optimizer.zero_grad()
+        output = model.forward(inputs, offsets, adj_matrix)
+        loss = criterion(output, cls)
+        if (i % tenth_iter == 0):
+            print(loss)
+        loss.backward()
+        optimizer.step()
+
+with open("sample_data.pkl", 'rb') as input:
+    model_data = pickle.load(input)
+
+model = GloveGAT()
+
+adj_matrix = model_data["adj_matrix"]
+embedding = model_data["embedding"]
+offsets = model_data["offsets"]
+outputs = model_data["outputs"]
+
+train(model, embedding, offsets, adj_matrix, outputs)

--- a/process_trees.py
+++ b/process_trees.py
@@ -2,21 +2,22 @@ from collections import deque
 import pickle
 #
 import torch
-import bcolz
+# import bcolz
 from torchtext.data.utils import get_tokenizer
 #
 from reddit_data import RedditTrees, JsonDataSource
+from machine_learning.glove_embedding import UNKNOWN_WORD, glove, word2idx
 
-UNKNOWN_WORD = "[unk]"
-
-# Setup glove embedding
-glove_path = "machine_learning/glove"
-
-word_vectors = bcolz.open(f'{glove_path}/6B.50.dat')[:]
-words = pickle.load(open(f'{glove_path}/6B.50_words.pkl', 'rb'))
-word2idx = pickle.load(open(f'{glove_path}/6B.50_idx.pkl', 'rb'))
-
-glove = {w: word_vectors[word2idx[w]] for w in words}
+# UNKNOWN_WORD = "[unk]"
+# 
+# # Setup glove embedding
+# glove_path = "machine_learning/glove"
+# 
+# word_vectors = bcolz.open(f'{glove_path}/6B.50.dat')[:]
+# words = pickle.load(open(f'{glove_path}/6B.50_words.pkl', 'rb'))
+# word2idx = pickle.load(open(f'{glove_path}/6B.50_idx.pkl', 'rb'))
+# 
+# glove = {w: word_vectors[word2idx[w]] for w in words}
 tokenizer = get_tokenizer("basic_english")
 
 # Breadth first search as a generator
@@ -78,7 +79,7 @@ if __name__ == "__main__":
 
     tree = all_trees[2]
 
-    tree_indices = get_tree_indices(tree)
+    tree_indices = assign_indices_to_nodes(tree)
     adj_mat = get_adj_matrix(tree, tree_indices)
     texts = get_tree_text(tree)
     embedding, offsets = get_tree_text_embedding(texts)


### PR DESCRIPTION
I fixed and refactored the preprocessing code, and added a new model that combines the embedding with the GAT layer. I still need to test this model, so I added some empty functions marking future work.

## Preprocessing changes
- Renamed `dfs` to `bfs` to be more accurate
- Refactored loading GloVe embedding to a separate file
- Removed `ngrams_iterator` since it's redundant in this case
- Renamed `create_adj_matrix` to `assign_indices_to_nodes`
- Fixed `get_adj_matrix` to return the sparse tensor
- Added code to save processed data of a single tree to a pkl file
- Changed output to return a float tensor, instead of a boolean tensor
- Changed `get_adj_matrix` so a node is its own neighbour. I realized that GAT doesn't have a way to process nodes with no neighbours, so by the paper, a node is always its own neighbour. We may change this if we can find a way to deal with neighbourless nodes.

## Model Changes
- Changed GAT model so it accepts the adjacency matrix in its `forward` function. In order to be able to predict on different graph structures, the adjacency matrix should be an input, rather than passed in initialization.
- Added the `GloveGAT` model. It combines an `EmbeddingBag` layer to a `GATFInal` layer. The embedding bag will average the word vectors of a sentence to pass the the GAT layer.

So far I have just created a scaffold of the new model and is subject to testing and changes. I still need to:
- Create functions for metrics (i.e. precision and recall)
- Create functions to split data into training and test
- Create functions to combine multiple trees together