### PR TITLE
Refactor: Tree Ordering

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from reddit_data import RedditTrees, JsonDataSource
+from reddit_data import RedditTreeBuilder, JsonDataSource
 
 # 1. Get json formatted reddit data from https://files.pushshift.io/reddit/comments/
 # 2. Use filter_subreddits.py to produce a single file containing only the subreddits you care about.
@@ -6,7 +6,7 @@ from reddit_data import RedditTrees, JsonDataSource
 
 path_to_json_data = "reddit_data/RC_2006-12" # for example, use comments from 2006
 jds = JsonDataSource(path_to_json_data)
-rt = RedditTrees(jds)
+rt = RedditTreeBuilder(jds)
 
 all_roots = list(jds.get_roots())
 all_trees = [rt.get_tree_rooted_at(c) for c in all_roots]

--- a/process_trees.py
+++ b/process_trees.py
@@ -3,7 +3,7 @@ import pickle
 import torch
 from torchtext.data.utils import get_tokenizer
 #
-from reddit_data import RedditTrees, JsonDataSource
+from reddit_data import RedditTreeBuilder, JsonDataSource
 from machine_learning.glove_embedding import UNKNOWN_WORD, glove, word2idx
 
 tokenizer = get_tokenizer("basic_english")
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     # Load reddit data
     path_to_json_data = "reddit_data/RC_2006-12" # for example, use comments from 2006
     jds = JsonDataSource(path_to_json_data)
-    rt = RedditTrees(jds)
+    rt = RedditTreeBuilder(jds)
 
     all_roots = list(jds.get_roots())
     all_trees = [rt.get_tree_rooted_at(c) for c in all_roots]

--- a/process_trees.py
+++ b/process_trees.py
@@ -1,4 +1,3 @@
-from collections import deque
 import pickle
 #
 import torch
@@ -9,40 +8,29 @@ from machine_learning.glove_embedding import UNKNOWN_WORD, glove, word2idx
 
 tokenizer = get_tokenizer("basic_english")
 
-# Breadth first search as a generator
-def bfs(tree):
-    queue = deque()
-    queue.append(tree)
-    while(queue):
-        node = queue.popleft()
-        yield node
-        for child in node.children:
-            queue.append(child)
 
-def assign_indices_to_nodes(tree):
-    return {node.comment.id: index for index, node in enumerate(bfs(tree))}
-
-# helper method to create an ajacency matrix given a mapping from each node to an index
-# The id_to_index mapping is passed to simplify the logic
-def get_adj_matrix(tree, id_to_index):
+# helper method to create an adjacency matrix given a tree of RedditNodes
+def get_adj_matrix(tree):
     node_edges = []
-    for node in bfs(tree):
-        index = id_to_index[node.comment.id]
+    for node in tree:
+        index = node.index
         node_edges.append([index, index]) # a node is its own neighbour
         for child in node.children:
-            child_index = id_to_index[child.comment.id]
-            node_edges.append([index, child_index])
+            node_edges.append([index, child.index])
 
     edges = torch.LongTensor(node_edges)
     ones = torch.ones(edges.size(0))
     adj_matrix = torch.sparse.IntTensor(edges.t(), ones)
     return adj_matrix
 
+
 def get_tree_text(tree):
-    return [node.comment.body for node in bfs(tree)]
+    return [node.comment.body for node in tree]
+
 
 def get_text_embedding(text):
     return torch.tensor([(word2idx[token] if token in glove else word2idx[UNKNOWN_WORD]) for token in tokenizer(text)])
+
 
 # Using an EmbeddingBag, the api requires text to be concatenated and offsets for each text to be specified
 def get_tree_text_embedding(texts):
@@ -53,10 +41,12 @@ def get_tree_text_embedding(texts):
     concat_text = torch.cat(text_lst)
     return concat_text, offsets
 
+
 # Returns the output to predict for all Reddit trees
 # In this case, it is binary if scores are above or equal to 1, the default Reddit score
 def get_output(tree):
-    return torch.FloatTensor([node.comment.score >= 1 for node in bfs(tree)])
+    return torch.FloatTensor([node.comment.score >= 1 for node in tree])
+
 
 if __name__ == "__main__":
     # Load reddit data
@@ -69,8 +59,7 @@ if __name__ == "__main__":
 
     tree = all_trees[2]
 
-    tree_indices = assign_indices_to_nodes(tree)
-    adj_mat = get_adj_matrix(tree, tree_indices)
+    adj_mat = get_adj_matrix(tree)
     texts = get_tree_text(tree)
     embedding, offsets = get_tree_text_embedding(texts)
     outputs = get_output(tree)

--- a/reddit_data/__init__.py
+++ b/reddit_data/__init__.py
@@ -1,3 +1,3 @@
 from .data_sources.data_source import DataSource
 from .data_sources.json_data_source import JsonDataSource
-from .reddit_trees import RedditTrees
+from .reddit_tree_builder import RedditTreeBuilder

--- a/reddit_data/data_models/reddit_comment.py
+++ b/reddit_data/data_models/reddit_comment.py
@@ -47,3 +47,6 @@ class RedditComment():
 
     def __eq__(self, other):
         return self.id == other.id
+
+    def __lt__(self, other):
+        return self.id < other.id

--- a/reddit_data/data_models/reddit_node.py
+++ b/reddit_data/data_models/reddit_node.py
@@ -1,7 +1,19 @@
+from collections import deque
+
 from reddit_data.data_models import RedditComment
 
 
 class RedditNode:
     def __init__(self, comment: RedditComment):
         self.comment = comment
+        self.index = None
         self.children = []
+
+    def __iter__(self):
+        queue = deque()
+        queue.append(self)
+        while queue:
+            node = queue.popleft()
+            yield node
+            for child in node.children:
+                queue.append(child)

--- a/reddit_data/reddit_tree_builder.py
+++ b/reddit_data/reddit_tree_builder.py
@@ -16,7 +16,7 @@ class RedditTreeBuilder:
 
         parent_node = RedditNode(parent_comment)
         child_comments = self.data.get_children(parent_comment.id)
-        for child_comment in child_comments:
+        for child_comment in sorted(child_comments):
             child_node = self.get_tree_rooted_at(child_comment)
             if child_node is not None:
                 parent_node.children.append(self.get_tree_rooted_at(child_comment))

--- a/reddit_data/reddit_tree_builder.py
+++ b/reddit_data/reddit_tree_builder.py
@@ -3,7 +3,7 @@ from reddit_data.data_models.reddit_node import RedditNode
 from reddit_data.data_sources.data_source import DataSource
 
 
-class RedditTrees:
+class RedditTreeBuilder:
     def __init__(self, data_source: DataSource):
         self.data = data_source
 

--- a/reddit_data/reddit_trees.py
+++ b/reddit_data/reddit_trees.py
@@ -8,6 +8,9 @@ class RedditTrees:
         self.data = data_source
 
     def get_tree_rooted_at(self, parent_comment: RedditComment) -> RedditNode:
+        return self._assign_indexes(self._build_tree(parent_comment))
+
+    def _build_tree(self, parent_comment):
         if parent_comment is None:
             return None
 
@@ -19,5 +22,13 @@ class RedditTrees:
                 parent_node.children.append(self.get_tree_rooted_at(child_comment))
 
         return parent_node
+
+    def _assign_indexes(self, tree):
+        index = 0
+        for node in tree:
+            node.index = index
+            index += 1
+        return tree
+
 
 


### PR DESCRIPTION
Simple refactors:

* Tree iteration ordering is now the responsibility of RedditNode. It's BFS.
* RedditTrees is renamed to RedditTreeBuilder.
* RedditTreeBuilder now has responsibility for assigning indexes to RedditNodes. These indexes may be useful for later debugging.
* Order of children is now defined and applied in RedditTreeBuilder.

Apologies for multiple PRs, Github is being a little weird today.
