### PR TITLE
Fix GATFinal and code for combining trees

### DIFF
--- a/machine_learning/gat.py
+++ b/machine_learning/gat.py
@@ -62,14 +62,17 @@ class GATFinal(GAT):
         """
         Instead of concatenating the results, they should be averaged for predictions
         """
-        results = torch.empty(0, self.output_size * self.K)
+        results = torch.empty(0, self.output_size)
         for i, x in enumerate(X):
             multi_head_results = torch.empty(1, 0)
             for k in range(self.K):
                 one_head_result = self.compute_embedding(X, i, k, adj)
                 multi_head_results = torch.cat((multi_head_results, one_head_result), dim=1)
-            results = torch.cat((results, multi_head_results), dim=0)
-        return F.softmax((1/self.K) * torch.reshape(sum(torch.chunk(results, self.K)), (-1,)), 0)
+
+            avg_results = (1/self.K) * sum(torch.chunk(multi_head_results.view(-1,), self.K))
+            results = torch.cat((results, avg_results.view(1,self.output_size)), dim=0)
+
+        return F.softmax(results, dim=1)
 
 
 # A simple function to train a net.

--- a/machine_learning/glove_gat.py
+++ b/machine_learning/glove_gat.py
@@ -12,7 +12,7 @@ class GloveGAT(nn.Module):
     def __init__(self):
         super().__init__()
         self.embedding = nn.EmbeddingBag.from_pretrained(torch.tensor(word_vectors))
-        self.gat = GATFinal(EMBED_DIM, output_size=1, K=1)
+        self.gat = GATFinal(EMBED_DIM, output_size=2, K=1)
 
     def forward(self, inputs, offsets, adj_matrix):
         embedded = self.embedding(inputs, offsets).float()

--- a/machine_learning/glove_gat.py
+++ b/machine_learning/glove_gat.py
@@ -4,6 +4,9 @@ import pickle
 import torch
 import torch.nn as nn
 import torch.optim as optim
+from torch.utils.data.dataset import random_split
+from ignite.engine import Engine, Events
+from ignite.metrics import Accuracy, Loss, Precision, Recall
 #
 from gat import GATFinal
 from glove_embedding import EMBED_DIM, word_vectors
@@ -18,34 +21,83 @@ class GloveGAT(nn.Module):
         embedded = self.embedding(inputs, offsets).float()
         return self.gat(embedded, adj_matrix)
 
-def create_train_and_test(data):
-    pass
+def create_train_and_test(data, split_percent=0.9):
+    train_len = int(len(model_data) * split_percent)
+    sub_train, sub_valid = random_split(model_data, [train_len, len(model_data) - train_len])
+    return sub_train, sub_valid
 
 def predict(model, data):
-    pass
+    preds = []
+    for tree_data in data:
+        output = model(
+            tree_data["embedding"],
+            tree_data["offsets"],
+            tree_data["adj_matrix"]
+        )
+        pred = output.argmax(1)
+        preds.append(pred)
+    return preds
 
-def train(model, inputs, offsets, adj_matrix, cls, lr=0.0001, iters=100):
+def get_percent_positive(data):
+    num_nodes = sum([len(tree["outputs"]) for tree in data])
+
+    # This relies on the fact that there are only two classes and will have
+    # the values 0 for positive and 1 for negative
+    num_negative = [tree["outputs"].argmax(1).sum().item() for tree in data]
+    total_negative = sum(num_negative)
+
+    return 1 - (total_negative / num_nodes)
+
+def train(model, data, lr=0.01):
+    # Metrics
+    train_loss = 0
+    train_acc = 0
+    num_nodes = sum([len(tree["outputs"]) for tree in data])
+
+    # model setup
     optimizer = optim.SGD(model.parameters(), lr=lr)
     criterion = nn.MSELoss()
 
-    tenth_iter = math.floor(iters / 10)
-    for i in range(iters):
+    tenth_iter = math.floor(len(data) / 10)
+    for i, tree_data in enumerate(data):
+        adj_matrix = tree_data["adj_matrix"]
+        inputs = tree_data["embedding"]
+        offsets = tree_data["offsets"]
+        cls = tree_data["outputs"]
+
         optimizer.zero_grad()
         output = model.forward(inputs, offsets, adj_matrix)
         loss = criterion(output, cls)
+        train_loss += loss.item()
         if (i % tenth_iter == 0):
             print(loss)
         loss.backward()
         optimizer.step()
+
+        num_correct = (output.argmax(1) == cls.argmax(1)).sum().item()
+        train_acc += num_correct
+
+    overall_loss = train_loss / num_nodes
+    overall_acc = train_acc / num_nodes
+    print(f"loss: {overall_loss: .4f}")
+    print(f"acc: {overall_acc: .4f}")
+
+def update_model(engine, batch):
+    adj_matrix = batch["adj_matrix"]
+    inputs = batch["embedding"]
+    offsets = batch["offsets"]
+    targets = batch["outputs"]
+
+    optimizer.zero_grad()
+    outputs = model(inputs, offsets, adj_matrix)
+    loss = criterion(outputs, targets)
+    loss.backward()
+    optimizer.step()
+    return loss.item()
 
 with open("sample_data.pkl", 'rb') as input:
     model_data = pickle.load(input)
 
 model = GloveGAT()
 
-adj_matrix = model_data["adj_matrix"]
-embedding = model_data["embedding"]
-offsets = model_data["offsets"]
-outputs = model_data["outputs"]
-
-train(model, embedding, offsets, adj_matrix, outputs)
+train(model, model_data)

--- a/process_trees.py
+++ b/process_trees.py
@@ -89,7 +89,7 @@ def combine_tree_values(trees):
 
 
 if __name__ == "__main__":
-# Load reddit data
+    # Load reddit data
     path_to_json_data = "reddit_data/RC_2006-12" # for example, use comments from 2006
     jds = JsonDataSource(path_to_json_data)
     rt = RedditTreeBuilder(jds)
@@ -97,8 +97,9 @@ if __name__ == "__main__":
     all_roots = list(jds.get_roots())
     all_trees = [rt.get_tree_rooted_at(c) for c in all_roots]
 
-    training_trees = all_trees[:100]
+    # only include trees that have at least one child
+    training_trees = list(filter(lambda tree: len(tree.children) > 0, all_trees))
     tree_data = [get_tree_values(tree) for tree in training_trees]
 
-    model_data = combine_tree_values(tree_data)
+    model_data = [combine_tree_values([tree]) for tree in tree_data]
     pickle.dump(model_data, open('machine_learning/sample_data.pkl', 'wb'))

--- a/process_trees.py
+++ b/process_trees.py
@@ -32,14 +32,9 @@ def get_text_embedding(text):
     return torch.tensor([(word2idx[token] if token in glove else word2idx[UNKNOWN_WORD]) for token in tokenizer(text)])
 
 
-# Using an EmbeddingBag, the api requires text to be concatenated and offsets for each text to be specified
 def get_tree_text_embedding(texts):
     text_lst = [get_text_embedding(text) for text in texts]
-    offsets = [0] + [len(entry) for entry in text_lst]
-
-    offsets = torch.tensor(offsets[:-1]).cumsum(dim=0)
-    concat_text = torch.cat(text_lst)
-    return concat_text, offsets
+    return text_lst
 
 
 # Returns the output to predict for all Reddit trees
@@ -48,26 +43,68 @@ def get_output(tree):
     return torch.FloatTensor([node.comment.score >= 1 for node in tree])
 
 
-if __name__ == "__main__":
-    # Load reddit data
-    path_to_json_data = "reddit_data/RC_2006-12" # for example, use comments from 2006
-    jds = JsonDataSource(path_to_json_data)
-    rt = RedditTreeBuilder(jds)
-
-    all_roots = list(jds.get_roots())
-    all_trees = [rt.get_tree_rooted_at(c) for c in all_roots]
-
-    tree = all_trees[2]
-
+def get_tree_values(tree):
     adj_mat = get_adj_matrix(tree)
     texts = get_tree_text(tree)
-    embedding, offsets = get_tree_text_embedding(texts)
+    embedding = get_tree_text_embedding(texts)
     outputs = get_output(tree)
 
-    model_data = {
+    return {
         "adj_matrix": adj_mat,
         "embedding": embedding,
+        "outputs": outputs
+    }
+
+
+# Combine the results of multiple trees to a large graph
+# trees is a list of dictionaries with preprocessed tree data
+def combine_tree_values(trees):
+    # Combine text embeddings and save offsets
+    text_embeddings = [embedding for tree in trees for embedding in tree["embedding"]]
+
+    offsets = [0] + [len(entry) for entry in text_embeddings]
+    offsets = torch.tensor(offsets[:-1]).cumsum(dim=0)
+    concat_text = torch.cat(text_embeddings)
+
+    # Construct combined adjacency matrix
+    num_nodes = [0] + [len(tree["outputs"]) for tree in trees]
+    edges = torch.cat(
+        [tree["adj_matrix"].coalesce().indices() + num_nodes[i] for i, tree in enumerate(trees)],
+        dim=1
+    )
+    ones = torch.ones(edges.size(1))
+    adj_matrix = torch.sparse.IntTensor(edges, ones)
+
+    # Concatenate all outputs
+    outputs = torch.cat([tree["outputs"] for tree in trees])
+
+    model_data = {
+        "adj_matrix": adj_matrix,
+        "embedding": concat_text,
         "offsets": offsets,
         "outputs": outputs
     }
-    pickle.dump(model_data, open('machine_learning/sample_data.pkl', 'wb'))
+    return model_data
+
+
+# if __name__ == "__main__":
+# Load reddit data
+# path_to_json_data = "reddit_data/RC_2006-12" # for example, use comments from 2006
+# jds = JsonDataSource(path_to_json_data)
+# rt = RedditTreeBuilder(jds)
+# 
+# all_roots = list(jds.get_roots())
+# all_trees = [rt.get_tree_rooted_at(c) for c in all_roots]
+
+with open("tree_test.pkl", 'rb') as input:
+    tree_data = pickle.load(input)
+
+# tree = all_trees[2]
+
+# adj_mat = get_adj_matrix(tree)
+# texts = get_tree_text(tree)
+# embedding, offsets = get_tree_text_embedding(texts)
+# outputs = get_output(tree)
+data = combine_tree_values(tree_data)
+
+# pickle.dump(model_data, open('machine_learning/sample_data.pkl', 'wb'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ bcolz
 torch
 torchtest
 torchtext
+pytorch-ignite


### PR DESCRIPTION
**Note**: I updated this PR to include pytorch ignite

I made some fixes to the `GATFinal` model and added code for combining trees together. I also created a training pipeline using pytorch ignite.

## GAT changes
- `GATFinal` was averaging across the wrong tensors, so the output was incorrect. I fixed this by changing were results are averaged.
- I changed `GloveGAT` to output to 2 nodes, since `GAT` uses softmax. I decided to do binary classification with two nodes instead of one, since the `GAT` model has an arbitrary number of output nodes and I wanted to keep the code general. It wanted, we could make the output one node by changing softmax to sigmoid. https://stats.stackexchange.com/questions/207049/neural-network-for-binary-classification-use-1-or-2-output-neurons

## Tree Processing Changes
- I added code for combing multiple trees into one large graph. Each graph can be considered a batch of trees that can be used to train the model.
- I modified the output to encode classes as one-hot vectors to fit pytorch API of calculating loss on batches of data
- I code to select only trees with at least one child to be used for training.

## Ignite training pipeline
- Added code for creating a training and validation set `create_train_and_test`
- Added code for checking how much of the data is in each binary class `get_percent_positive`. About 75% of the comments have a positive score.
- Added code to make predictions `predict_on_batch`
- Added code for training on batches
- Added code for calculating Accuracy, precision, and recall on the validation set

You can test code as follows:
- run `pip install -r requirements.txt` to install `pytorch-ignite`
- run `python process_trees.py`. This creates a pickle file of 100 processed trees
- run `cd machine_learning && python glove_gat.py`. This trains the model on the pickle file just created