### PR TITLE
Updated Reddit Tree parsing, tokenizer, and pyGAT repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/t-davidson/hate-speech-and-offensive-language.git
 [submodule "pyGAT"]
 	path = pyGAT
-	url = https://github.com/Diego999/pyGAT.git
+	url = https://github.com/jpngfile/pyGAT.git

--- a/reddit_data/reddit_tree_builder.py
+++ b/reddit_data/reddit_tree_builder.py
@@ -1,3 +1,4 @@
+import math
 from reddit_data.data_models import RedditComment
 from reddit_data.data_models.reddit_node import RedditNode
 from reddit_data.data_sources.data_source import DataSource
@@ -7,19 +8,19 @@ class RedditTreeBuilder:
     def __init__(self, data_source: DataSource):
         self.data = data_source
 
-    def get_tree_rooted_at(self, parent_comment: RedditComment) -> RedditNode:
-        return self._assign_indexes(self._build_tree(parent_comment))
+    def get_tree_rooted_at(self, parent_comment: RedditComment, depth=math.inf) -> RedditNode:
+        return self._assign_indexes(self._build_tree(parent_comment, depth))
 
-    def _build_tree(self, parent_comment):
-        if parent_comment is None:
+    def _build_tree(self, parent_comment, depth):
+        if parent_comment is None or depth <= 0:
             return None
 
         parent_node = RedditNode(parent_comment)
         child_comments = self.data.get_children(parent_comment.id)
         for child_comment in sorted(child_comments):
-            child_node = self.get_tree_rooted_at(child_comment)
+            child_node = self._build_tree(child_comment, depth - 1)
             if child_node is not None:
-                parent_node.children.append(self.get_tree_rooted_at(child_comment))
+                parent_node.children.append(child_node)
 
         return parent_node
 

--- a/text_preprocessing.py
+++ b/text_preprocessing.py
@@ -4,7 +4,7 @@ import torch
 from torchtext.data.utils import get_tokenizer
 from nltk.stem.porter import PorterStemmer
 
-tokenizer = get_tokenizer("basic_english")
+tokenizer = get_tokenizer("spacy")
 puncTable = str.maketrans('', '', string.punctuation)
 stemmer = PorterStemmer()
 


### PR DESCRIPTION
I made some changes to how data is processed to be able to parse through more Reddit comments and experiment on Google Colab.

## Changes
- Changed the  `pyGAT` repo to a forked version. I made changes to the import paths so I could include methods from the package in my Google Colab experiments
- Added a depth parameter to the `get_tree_rooted_at` in `reddit_tree_builder`. I am only predicting the class of the parent node, and since the GAT model only uses information from 2 degrees of separation, I only needed 2 layers of the tree. I changed the method to disregard any nodes of deeper depth, which has decreased processing time significantly.
- I also made some minor fixes to `_build_tree`. It was performing some duplicate work, so I removed the redundancies
- Changed the `torchtext` tokenizer type. The Google colab version doesn't recognize "basic_english" so I changed it to "spacy"

My Google Colab experiments can be found at: 
https://colab.research.google.com/drive/13EbUn6JYT26Ks87qjpRYc_C-5K_GoAdz
