### PR TITLE
Added score to input, and more adj matrix options

### DIFF
--- a/machine_learning/adjacency_matrix.py
+++ b/machine_learning/adjacency_matrix.py
@@ -23,6 +23,7 @@ def get_adj_matrix(
         is_undirected=True,
         has_parent_loop=False,  # If the root node has an edge to itself
         has_parent_edges=True,  # If the parent's children are connected to the parent
+        has_child_edges = True, # If the children are connected to the parent
 ):
     node_edges = []
     for node in tree:
@@ -40,7 +41,11 @@ def get_adj_matrix(
 
     # Remove all edges directed to the parent node
     if (not has_parent_edges):
-        node_edges = list(filter(lambda edge: edge[1] != 0, node_edges))
+        node_edges = list(filter(lambda edge: edge[0] == 0 or edge[1] != 0, node_edges))
+
+    # Remove all child edges from the parent
+    if (not has_child_edges):
+        node_edges = list(filter(lambda edge: edge[1] == 0 or edge[0] != 0, node_edges))
 
     edges = torch.LongTensor(node_edges)
     ones = torch.ones(edges.size(0))

--- a/machine_learning/dataset_builder.py
+++ b/machine_learning/dataset_builder.py
@@ -1,10 +1,21 @@
 import random
+import torch
 
 from machine_learning.experiment_types import *
 from machine_learning.data_balance import balance_trees
 from machine_learning.adjacency_matrix import get_adj_matrix
-from machine_learning.feature_extraction import get_output
+from machine_learning.feature_extraction import get_output, get_scores
 from machine_learning.text_embedders import TextEmbedder
+
+def append_scores(trees, embedding, mask_parent=True):
+    scores = [torch.tensor(get_scores(tree)) for tree in trees]
+    combined_embedding = []
+    for i, score in enumerate(scores):
+        if (mask_parent):
+            score[0] = 0
+        reshaped_score = score.view(len(score), 1).float()
+        combined_embedding.append(torch.cat((embedding[i], reshaped_score), dim=1))
+    return combined_embedding
 
 
 # Methods for outputs
@@ -13,16 +24,31 @@ def get_model_data(
         embedder: TextEmbedder,
         batch_size,
         output_type: OutputType,
+        has_scores = True, # Whether the embedding has comment scores appended
         is_undirected=True,
         has_parent_loop=False,  # If the root node has an edge to itself
         has_parent_edges=True,  # If the parent's children are connected to the parent
+        has_child_edges = True, # If the children are connected to the parent
 ):
     # Balance the trees
     balanced_trees = balance_trees(trees, output_type)
     # Create adjacency matrices
-    adj_matrices = [get_adj_matrix(tree, is_undirected, has_parent_loop, has_parent_edges) for tree in balanced_trees]
+    adj_matrices = [get_adj_matrix(
+        tree,
+        is_undirected,
+        has_parent_loop,
+        has_parent_edges,
+        has_child_edges,
+    ) for tree in balanced_trees]
     # Create inputs
     embeddings = embedder.get_embeddings(balanced_trees)
+    # Optionally append scores
+    if (has_scores):
+        embeddings = append_scores(
+            balanced_trees,
+            embeddings,
+            mask_parent=output_type == OutputType.SCORE_POLARITY
+        )
     # Create outputs
     outputs = [get_output(tree, output_type) for tree in balanced_trees]
     # Zip all data together
@@ -33,7 +59,6 @@ def get_model_data(
     } for adj_mat, emb, output in zip(adj_matrices, embeddings, outputs)]
     # Scramble the data
     random.shuffle(tree_data)
-    # Split into train and balanced valid set
     # Batch trees together
     return [
         embedder.batch_trees(tree_data[i:(i + batch_size)])

--- a/machine_learning/feature_extraction.py
+++ b/machine_learning/feature_extraction.py
@@ -8,6 +8,10 @@ from machine_learning.experiment_types import *
 from machine_learning.language_collections import hate_dict
 
 
+def get_scores(tree):
+    return [node.comment.score for node in tree]
+
+
 def get_tree_text(tree):
     return [node.comment.body for node in tree]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ sklearn
 scipy
 nltk
 hatesonar
+profanity-check
+textblob
+spacy


### PR DESCRIPTION
I updated the functions for creating model data and the adjacency matrix for the experiment where I tried appending the score to the input embedding. I also updated the `requirements.txt` file

## Changes
- Added adjacency matrix option to remove edges from the parent to the children
- Fixed adjacency matrix so parent loop is independent from other options
- Added functions to get the scores from a tree
- Added functions to append score to an embedding. For score polarity, the parent score gets masked to 0
- Added `profanity-check`, `textblob`, and `spacy` to requirements.txt

Note: to use spacy, you need to download the tokenizer model:
```
python -m spacy download en
```
https://spacy.io/models/en

## Usage
```
from reddit_data_interface import RedditTreeBuilder, JsonDataSource
from machine_learning.dataset_builder import get_model_data
from machine_learning.experiment_types import *
from machine_learning.text_embedders import BowEmbedder

path_to_json_data = ["RC_2006-12"]
jds = JsonDataSource(path_to_json_data)
rt = RedditTreeBuilder(jds)

all_roots = list(jds.iter_parents())

# Generate trees
trees = []
num_trees = 1000
for i in range(num_trees):
  tree = rt.get_tree_rooted_at(all_roots[i], depth=3)
  if (len(tree.children) < 2):
    continue
  trees.append(tree)
print(len(trees))

model_data = get_model_data(
    trees,
    embedder=BowEmbedder(VectorizerType.TFIDF),
    batch_size=10,
    output_type=OutputType.SENTIMENT,
    has_scores = True,
    is_undirected=True,
    has_parent_loop=True,
    has_parent_edges=True,
    has_child_edges=False,
)
```